### PR TITLE
[infiotinc/docker-suricata] add support for netmap for suricata 6.0

### DIFF
--- a/6.0/Dockerfile.amd64
+++ b/6.0/Dockerfile.amd64
@@ -45,9 +45,20 @@ RUN dnf -y install \
         zlib-devel
 
 ARG VERSION
+ARG NETMAP
 
 RUN if [ "${VERSION}" = "master" ]; then \
         cargo install --root /usr/local cbindgen; \
+fi
+
+WORKDIR /src
+
+WORKDIR /src/netmap
+
+RUN if [ "${NETMAP}" = "yes" ]; then \
+        git clone https://github.com/luigirizzo/netmap; \
+        cd /src/netmap/netmap; \
+        git checkout -b infiot-netmap 9083fe492efc70fa98d103d1eba4ebfa4ce33844; \
 fi
 
 WORKDIR /src
@@ -67,24 +78,43 @@ WORKDIR /src/suricata-${VERSION}
 
 ARG CONFIGURE_ARGS
 
-RUN ./configure \
-        --prefix=/usr \
-        --disable-shared \
-        --disable-gccmarch-native \
-        --enable-lua \
-        --enable-nfqueue \
-        --enable-hiredis \
-        ${CONFIGURE_ARGS}
+RUN if [ "${NETMAP}" = "yes" ]; then \
+        CPATH=/src/netmap/netmap/sys ./configure \
+                --prefix=/usr \
+                --disable-shared \
+                --disable-gccmarch-native \
+                --enable-lua \
+                --enable-nfqueue \
+                --enable-netmap \
+                --with-netmap-includes="/src/netmap/netmap/sys/" \
+                --with-netmap-libraries="/src/netmap/netmap/" \
+                --enable-hiredis \
+                ${CONFIGURE_ARGS} ; \
+else \
+        ./configure \
+                --prefix=/usr \
+                --disable-shared \
+                --disable-gccmarch-native \
+                --enable-lua \
+                --enable-nfqueue \
+                --enable-hiredis \
+                ${CONFIGURE_ARGS} ; \
+fi
 
 ARG CORES=2
 
-RUN make -j "${CORES}"
+RUN if [ "${NETMAP}" = "yes" ]; then \
+        CPATH=/src/netmap/netmap/sys make -j "${CORES}"; \
+else \
+        make -j "${CORES}"; \
+fi
 
 RUN make install install-conf DESTDIR=/fakeroot
 
 # Something about the Docker mounts won't let us copy /var/run in the
 # next stage.
 RUN rm -rf /fakeroot/var
+RUN rm -rf /fakeroot/netmap
 
 FROM almalinux/8-base:latest AS runner
 RUN \

--- a/6.0/Dockerfile.arm64v8
+++ b/6.0/Dockerfile.arm64v8
@@ -1,5 +1,7 @@
 FROM arm64v8/alpine:latest AS builder
 
+COPY qemu-aarch64-static /usr/bin
+
 RUN apk add \
         automake \
         autoconf \
@@ -32,6 +34,17 @@ RUN apk add \
         zlib-dev
 
 ARG VERSION
+ARG NETMAP
+
+WORKDIR /src
+
+WORKDIR /src/netmap
+
+RUN if [ "${NETMAP}" = "yes" ]; then \
+        git clone https://github.com/luigirizzo/netmap; \
+        cd /src/netmap/netmap; \
+        git checkout -b infiot-netmap 9083fe492efc70fa98d103d1eba4ebfa4ce33844; \
+fi
 
 WORKDIR /src
 
@@ -50,26 +63,47 @@ WORKDIR /src/suricata-${VERSION}
 
 ARG CONFIGURE_ARGS
 
-RUN ./configure \
-        --prefix=/usr \
-        --sysconfdir=/etc \
-        --localstatedir=/var \
-        --disable-shared \
-        --disable-gccmarch-native \
-        --enable-ebpf \
-        --enable-nfqueue \
-        --enable-hiredis \
-	${CONFIGURE_ARGS}
+RUN if [ "${NETMAP}" = "yes" ]; then \
+        CPATH=/src/netmap/netmap/sys ./configure \
+                --prefix=/usr \
+                --sysconfdir=/etc \
+                --localstatedir=/var \
+                --disable-shared \
+                --disable-gccmarch-native \
+                --enable-ebpf \
+                --enable-nfqueue \
+                --enable-netmap \
+                --with-netmap-includes="/src/netmap/netmap/sys/" \
+                --with-netmap-libraries="/src/netmap/netmap/" \
+                --enable-hiredis \
+	        ${CONFIGURE_ARGS} ; \
+else \
+        ./configure \
+                --prefix=/usr \
+                --sysconfdir=/etc \
+                --localstatedir=/var \
+                --disable-shared \
+                --disable-gccmarch-native \
+                --enable-ebpf \
+                --enable-nfqueue \
+                --enable-hiredis \
+	        ${CONFIGURE_ARGS} ; \
+fi
 
 ARG CORES=2
 
-RUN make -j "${CORES}"
+RUN if [ "${NETMAP}" = "yes" ]; then \
+        CPATH=/src/netmap/netmap/sys make -j "${CORES}"; \
+else \
+        make -j "${CORES}"; \
+fi
 
 RUN make install install-conf DESTDIR=/fakeroot
 
 # Something about the Docker mounts won't let us copy /var/run in the
 # next stage.
 RUN rm -rf /fakeroot/var
+RUN rm -rf /fakeroot/netmap
 
 FROM arm64v8/alpine:latest AS runner
 

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -36,7 +36,7 @@ if [ $# -gt 0 -a "${1:0:1}" != "-" ]; then
     exec $@
 fi
 
-run_as_user="yes"
+run_as_user="no"
 
 check_for_cap() {
     echo -n "Checking for capability $1: "

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ fi
 MAJOR=$(basename $(pwd))
 VERSION=$(cat VERSION)
 LATEST=$(cat ../LATEST)
+NETMAP=$(echo $NETMAP)
 
 manifest_only="no"
 
@@ -77,6 +78,7 @@ build() {
                --rm \
 	       --build-arg VERSION="${VERSION}" \
                --build-arg CORES="${CORES}" \
+               --build-arg NETMAP="${NETMAP}" \
                --build-arg CONFIGURE_ARGS="${configure_args}" \
                --tag "${tag}" \
                -f Dockerfile.${arch} \


### PR DESCRIPTION
Introduced build-arg NETMAP to build with and without netmap

ARM requires `qemu-aarch64-static` and `suricata-update` fails
to determine proper OS and hence they are skipped.